### PR TITLE
Changes in has_key in python3

### DIFF
--- a/findsequenceoccurance.py
+++ b/findsequenceoccurance.py
@@ -10,11 +10,11 @@ while start < pointer and pointer < length:
         pointer = pointer + 1
     key = arr[start: pointer]
     if len(key) > 1:
-    	if test.has_key(key):
+    	if test.__contains__(key):
         	test[key] = test[key] + 1
     	else:
         	test[key] = 1
     start = pointer
     pointer = pointer + 1
     temp = 98
-print test
+print(test)


### PR DESCRIPTION
I ran the code and found the above changes for python3, has_key is replaced with __contains__ or you can use in operator instead of it.
The error was AttributeError: 'dict' object has no attribute 'has_key'